### PR TITLE
フッター/ヘッダーの情報を翻訳した

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -14,6 +14,7 @@ const TITLE_WITH_TRANSLATIONS = {
   'en-US': 'React Hooks library for data fetching',
   'zh-CN': '用于数据请求的 React Hooks 库',
   'es-ES': 'Biblioteca React Hooks para la obtención de datos',
+  'ja': 'データ取得のための React Hooks ライブラリ',
 }
 
 export default {
@@ -94,6 +95,8 @@ export default {
         return '在 GitHub 上编辑本页'
       case 'es-ES':
         return 'Edite esta página en GitHub'
+      case 'ja':
+        return 'Github で編集する'
       default:
         return 'Edit this page on GitHub'
     }
@@ -105,9 +108,13 @@ export default {
           <span className="mr-2">由</span><span className="mr-2"><Vercel/></span>驱动
         </a>
       case 'es-ES':
-      return <a href="https://vercel.com/?utm_source=swr_es-es" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
-      <span className="mr-2">Desarrollado por</span><span className="mr-2"><Vercel/></span>
-    </a>
+        return <a href="https://vercel.com/?utm_source=swr_es-es" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
+            <span className="mr-2">Desarrollado por</span><span className="mr-2"><Vercel/></span>
+          </a>
+      case 'ja':
+        return <a href="https://vercel.com/?utm_source=swr_ja" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
+            <span className="mr-2">提供</span><span className="mr-2"><Vercel/></span>
+          </a>
       default:
         return <a href="https://vercel.com/?utm_source=swr" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
           <span className="mr-1">Powered by</span><span><Vercel/></span>


### PR DESCRIPTION
## 概要

`./theme.config.js` に日本語の翻訳情報などを追加した。

### 注意事項

- `Powered by` は、「 提供 」として翻訳した
- `Edit this page on GitHub` は、「 Github で編集する 」として翻訳した

## Issues

fix #94